### PR TITLE
Improve period handling

### DIFF
--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -125,7 +125,7 @@ class Period(AccessorTimeBase):
     def midx(self):
         return (
             self._obj.time.to_series()
-            .apply(lambda x: min(self._max_per_month, ((x.day-1) // self._ndays) + 1))
+            .apply(lambda x: min(self._max_per_month, ((x.day - 1) // self._ndays) + 1))
             .values.astype("int")
         )
 

--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -28,7 +28,7 @@ class AccessorBase:
 
 
 class AccessorTimeBase(AccessorBase):
-    """Base class for accessors with required time dimension"""
+    """Base class for accessors with required time dimension."""
 
     def __init__(self, xarray_obj):
         """Construct with DataArray|Dataset."""
@@ -116,7 +116,7 @@ class LabelMaker:
 class Period(AccessorTimeBase):
     # pylint: disable=no-member,undefined-variable
     """
-    Baseclass to extend time dimension with period functionality
+    Baseclass to extend time dimension with period functionality.
 
     Adds functionality for working with periods, such as dekads and pentads
     """
@@ -150,7 +150,7 @@ class Period(AccessorTimeBase):
 @xarray.register_dataset_accessor("dekad")
 @xarray.register_dataarray_accessor("dekad")
 class Dekad(Period):
-    """Accessor class for dekad period"""
+    """Accessor class for dekad period."""
 
     _cfactor = 10.5
     _nperiods = 3
@@ -160,7 +160,7 @@ class Dekad(Period):
 @xarray.register_dataset_accessor("pentad")
 @xarray.register_dataarray_accessor("pentad")
 class Pentad(Period):
-    """Accessor class for pentad period"""
+    """Accessor class for pentad period."""
 
     _cfactor = 5.19
     _nperiods = 6

--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -125,7 +125,7 @@ class Period(AccessorTimeBase):
     def midx(self):
         return (
             self._obj.time.to_series()
-            .apply(lambda x: (x.day // self._cfactor) + 1)
+            .apply(lambda x: min(self._max_per_month, ((x.day-1) // self._ndays) + 1))
             .values.astype("int")
         )
 
@@ -133,7 +133,7 @@ class Period(AccessorTimeBase):
     def yidx(self):
         return (
             self._obj.time.to_series()
-            .apply(lambda x: ((x.month - 1) * self._nperiods))
+            .apply(lambda x: ((x.month - 1) * self._max_per_month))
             .values
             + self.midx
         ).astype("int")
@@ -152,8 +152,8 @@ class Period(AccessorTimeBase):
 class Dekad(Period):
     """Accessor class for dekad period."""
 
-    _cfactor = 10.5
-    _nperiods = 3
+    _ndays = 10
+    _max_per_month = 3
     _label = "d"
 
 
@@ -162,8 +162,8 @@ class Dekad(Period):
 class Pentad(Period):
     """Accessor class for pentad period."""
 
-    _cfactor = 5.19
-    _nperiods = 6
+    _ndays = 5
+    _max_per_month = 6
     _label = "p"
 
 

--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -11,8 +11,10 @@ from . import ops
 
 __all__ = [
     "Anomalies",
+    "Dekad",
     "IterativeAggregation",
     "LabelMaker",
+    "Pentad",
     "PixelAlgorithms",
     "WhittakerSmoother",
 ]
@@ -23,6 +25,39 @@ class AccessorBase:
 
     def __init__(self, xarray_obj):
         self._obj = xarray_obj
+
+
+class AccessorTimeBase(AccessorBase):
+    """Base class for accessors with required time dimension"""
+
+    def __init__(self, xarray_obj):
+        """Construct with DataArray|Dataset."""
+        if not np.issubdtype(xarray_obj, np.datetime64):
+            raise TypeError(
+                "'This accessor is only available for "
+                "DataArray with datetime64 dtype"
+            )
+
+        if not hasattr(xarray_obj, "time"):
+            raise ValueError("Data array is missing 'time' accessor!")
+
+        if "time" not in xarray_obj.dims:
+            xarray_obj = xarray_obj.expand_dims("time")
+        self._obj = xarray_obj
+
+        super().__init__(xarray_obj)
+
+    @property
+    def year(self):
+        return self._obj.time.dt.year
+
+    @property
+    def month(self):
+        return self._obj.time.dt.month
+
+    @property
+    def day(self):
+        return self._obj.time.dt.day
 
 
 @xarray.register_dataarray_accessor("labeler")
@@ -76,6 +111,60 @@ class LabelMaker:
     @staticmethod
     def _gen_labels(x, lbl, c):
         return f"{x.year}{x.month:02}" + f"{lbl}{int(x.day//c+1)}"
+
+
+class Period(AccessorTimeBase):
+    # pylint: disable=no-member,undefined-variable
+    """
+    Baseclass to extend time dimension with period functionality
+
+    Adds functionality for working with periods, such as dekads and pentads
+    """
+
+    @property
+    def month_idx(self):
+        return (
+            self._obj.time.to_series()
+            .apply(lambda x: (x.day // self._cfactor) + 1)
+            .values.astype("int")
+        )
+
+    @property
+    def year_idx(self):
+        return (
+            self._obj.time.to_series()
+            .apply(lambda x: ((x.month - 1) * self._nperiods))
+            .values
+            + self.month_idx
+        ).astype("int")
+
+    @property
+    def label(self):
+        return (
+            self.year.astype("str")
+            .str.cat(self.month.astype("str").str.zfill(2))
+            .str.cat(self.month_idx.astype("str"), sep=self._label)
+        ).values
+
+
+@xarray.register_dataset_accessor("dekad")
+@xarray.register_dataarray_accessor("dekad")
+class Dekad(Period):
+    """Accessor class for dekad period"""
+
+    _cfactor = 10.5
+    _nperiods = 3
+    _label = "d"
+
+
+@xarray.register_dataset_accessor("pentad")
+@xarray.register_dataarray_accessor("pentad")
+class Pentad(Period):
+    """Accessor class for pentad period"""
+
+    _cfactor = 5.19
+    _nperiods = 6
+    _label = "p"
 
 
 @xarray.register_dataset_accessor("iteragg")

--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -122,7 +122,7 @@ class Period(AccessorTimeBase):
     """
 
     @property
-    def month_idx(self):
+    def midx(self):
         return (
             self._obj.time.to_series()
             .apply(lambda x: (x.day // self._cfactor) + 1)
@@ -130,12 +130,12 @@ class Period(AccessorTimeBase):
         )
 
     @property
-    def year_idx(self):
+    def yidx(self):
         return (
             self._obj.time.to_series()
             .apply(lambda x: ((x.month - 1) * self._nperiods))
             .values
-            + self.month_idx
+            + self.midx
         ).astype("int")
 
     @property
@@ -143,7 +143,7 @@ class Period(AccessorTimeBase):
         return (
             self.year.astype("str")
             .str.cat(self.month.astype("str").str.zfill(2))
-            .str.cat(self.month_idx.astype("str"), sep=self._label)
+            .str.cat(self.midx.astype("str"), sep=self._label)
         ).values
 
 

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -32,6 +32,38 @@ def res_spi():
     )
 
 
+def test_period_years_dekad(darr):
+    np.testing.assert_array_equal(darr.time.dekad.year, darr.time.dt.year)
+
+
+def test_period_years_pentad(darr):
+    np.testing.assert_array_equal(darr.time.pentad.year, darr.time.dt.year)
+
+
+def test_period_months_dekad(darr):
+    np.testing.assert_array_equal(darr.time.dekad.month, darr.time.dt.month)
+
+
+def test_period_months_pentad(darr):
+    np.testing.assert_array_equal(darr.time.pentad.month, darr.time.dt.month)
+
+
+def test_period_month_idx_dekad(darr):
+    np.testing.assert_array_equal(darr.time.dekad.month_idx, [1, 2, 3, 3, 1])
+
+
+def test_period_month_idx_pentad(darr):
+    np.testing.assert_array_equal(darr.time.pentad.month_idx, [1, 3, 5, 6, 2])
+
+
+def test_period_year_idx_dekad(darr):
+    np.testing.assert_array_equal(darr.time.dekad.year_idx, [1, 2, 3, 3, 4])
+
+
+def test_period_year_idx_pentad(darr):
+    np.testing.assert_array_equal(darr.time.pentad.year_idx, [1, 3, 5, 6, 8])
+
+
 def test_labels_dekad(darr):
 
     np.testing.assert_array_equal(
@@ -40,9 +72,22 @@ def test_labels_dekad(darr):
     )
 
 
+def test_period_labels_dekad(darr):
+
+    np.testing.assert_array_equal(
+        darr.time.dekad.label,
+        ["200001d1", "200001d2", "200001d3", "200001d3", "200002d1"],
+    )
+
+
 def test_labels_dekad_single(darr):
 
     np.testing.assert_array_equal(darr.isel(time=0).time.labeler.dekad, ["200001d1"])
+
+
+def test_period_labels_dekad_single(darr):
+
+    np.testing.assert_array_equal(darr.isel(time=0).time.dekad.label, ["200001d1"])
 
 
 def test_labels_pentad(darr):
@@ -53,14 +98,32 @@ def test_labels_pentad(darr):
     )
 
 
+def test_period_labels_pentad(darr):
+
+    np.testing.assert_array_equal(
+        darr.time.pentad.label,
+        ["200001p1", "200001p3", "200001p5", "200001p6", "200002p2"],
+    )
+
+
 def test_labels_pentad_single(darr):
 
     np.testing.assert_array_equal(darr.isel(time=0).time.labeler.pentad, ["200001p1"])
 
 
+def test_period_labels_pentad_single(darr):
+
+    np.testing.assert_array_equal(darr.isel(time=0).time.pentad.label, ["200001p1"])
+
+
 def test_labels_exception(darr):
     with pytest.raises(TypeError):
         _ = darr.x.labeler.dekad
+
+
+def test_period_exception(darr):
+    with pytest.raises(TypeError):
+        _ = darr.x.dekad
 
 
 def test_algo_lroo(darr):

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -48,20 +48,20 @@ def test_period_months_pentad(darr):
     np.testing.assert_array_equal(darr.time.pentad.month, darr.time.dt.month)
 
 
-def test_period_month_idx_dekad(darr):
-    np.testing.assert_array_equal(darr.time.dekad.month_idx, [1, 2, 3, 3, 1])
+def test_period_midx_dekad(darr):
+    np.testing.assert_array_equal(darr.time.dekad.midx, [1, 2, 3, 3, 1])
 
 
-def test_period_month_idx_pentad(darr):
-    np.testing.assert_array_equal(darr.time.pentad.month_idx, [1, 3, 5, 6, 2])
+def test_period_midx_pentad(darr):
+    np.testing.assert_array_equal(darr.time.pentad.midx, [1, 3, 5, 6, 2])
 
 
-def test_period_year_idx_dekad(darr):
-    np.testing.assert_array_equal(darr.time.dekad.year_idx, [1, 2, 3, 3, 4])
+def test_period_yidx_dekad(darr):
+    np.testing.assert_array_equal(darr.time.dekad.yidx, [1, 2, 3, 3, 4])
 
 
-def test_period_year_idx_pentad(darr):
-    np.testing.assert_array_equal(darr.time.pentad.year_idx, [1, 3, 5, 6, 8])
+def test_period_yidx_pentad(darr):
+    np.testing.assert_array_equal(darr.time.pentad.yidx, [1, 3, 5, 6, 8])
 
 
 def test_labels_dekad(darr):


### PR DESCRIPTION
This is a first step in addressing [issue #60 over on seasmon-aws](https://github.com/WFP-VAM/seasmon-aws/issues/60).

The PR implements:

- a new base class `AccessorTimeBase` that inherits from `AccessorBase`, enforces the presence of a proper time dimension and exposes the `year`, `month` and `day` properties from the datetime accessor as class properties.
- a base class `Period` that serves as a parent class to the subsequent classes exposed as xarray accessors. In addition the class implements the `month_ix` and `year_ix` properties that return the index of the period within the month / year and the `label` property that returns the full period label including year and month (equivalent to `LabelMaker` class functionality)
- Two child classes to `Period` which are exposed as accessor: `Dekad` and `Pentad` that contain class variables to control the properties inherited by `Period`.

When the PR is merged, the following will be possible (example with dekad):

```python
x = xarrax.Dataset(...) # also works with DataArray, note it requires a time dimension to be present


# access year, month, day
x.time.dekad.year
x.time.dekad.month
x.time.dekad.day

# access indices
x.time.dekad.year_ix
x.time.dekad.month_ix

# access labels
x.time.dekad.label
```

This basically makes `LabelMaker` redundant, but we can't remove it at the moment as it's used downstream. Should we deprecate it?

Please see individual notes in my review below.

