### PR TITLE
Rework indexes and class variables for `Period`s

### DIFF
--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -125,7 +125,7 @@ class Period(AccessorTimeBase):
     def midx(self):
         return (
             self._obj.time.to_series()
-            .apply(lambda x: min(self._max_per_month, ((x.day - 1) // self._ndays) + 1))
+            .apply(lambda x: min(self.max_per_month, ((x.day - 1) // self.ndays) + 1))
             .to_xarray()
         )
 
@@ -133,7 +133,7 @@ class Period(AccessorTimeBase):
     def yidx(self):
         return (
             self._obj.time.to_series()
-            .apply(lambda x: ((x.month - 1) * self._max_per_month))
+            .apply(lambda x: ((x.month - 1) * self.max_per_month))
             .to_xarray() + self.midx
 
         )
@@ -152,8 +152,8 @@ class Period(AccessorTimeBase):
 class Dekad(Period):
     """Accessor class for dekad period."""
 
-    _ndays = 10
-    _max_per_month = 3
+    ndays = 10
+    max_per_month = 3
     _label = "d"
 
 
@@ -162,8 +162,8 @@ class Dekad(Period):
 class Pentad(Period):
     """Accessor class for pentad period."""
 
-    _ndays = 5
-    _max_per_month = 6
+    ndays = 5
+    max_per_month = 6
     _label = "p"
 
 

--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -134,8 +134,8 @@ class Period(AccessorTimeBase):
         return (
             self._obj.time.to_series()
             .apply(lambda x: ((x.month - 1) * self.max_per_month))
-            .to_xarray() + self.midx
-
+            .to_xarray()
+            + self.midx
         )
 
     @property

--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -126,7 +126,7 @@ class Period(AccessorTimeBase):
         return (
             self._obj.time.to_series()
             .apply(lambda x: min(self._max_per_month, ((x.day - 1) // self._ndays) + 1))
-            .values.astype("int")
+            .to_xarray()
         )
 
     @property
@@ -134,9 +134,9 @@ class Period(AccessorTimeBase):
         return (
             self._obj.time.to_series()
             .apply(lambda x: ((x.month - 1) * self._max_per_month))
-            .values
-            + self.midx
-        ).astype("int")
+            .to_xarray() + self.midx
+
+        )
 
     @property
     def label(self):

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -49,18 +49,22 @@ def test_period_months_pentad(darr):
 
 
 def test_period_midx_dekad(darr):
+    assert isinstance(darr.time.dekad.midx, xr.DataArray)
     np.testing.assert_array_equal(darr.time.dekad.midx, [1, 2, 3, 3, 1])
 
 
 def test_period_midx_pentad(darr):
+    assert isinstance(darr.time.pentad.midx, xr.DataArray)
     np.testing.assert_array_equal(darr.time.pentad.midx, [1, 3, 5, 6, 2])
 
 
 def test_period_yidx_dekad(darr):
+    assert isinstance(darr.time.dekad.yidx, xr.DataArray)
     np.testing.assert_array_equal(darr.time.dekad.yidx, [1, 2, 3, 3, 4])
 
 
 def test_period_yidx_pentad(darr):
+    assert isinstance(darr.time.pentad.yidx, xr.DataArray)
     np.testing.assert_array_equal(darr.time.pentad.yidx, [1, 3, 5, 6, 8])
 
 

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -124,13 +124,16 @@ def test_period_class_variables_dekad(darr):
     assert darr.time.dekad.ndays == 10
     assert darr.time.dekad.max_per_month == 3
 
+
 def test_period_class_variables_pentad(darr):
     assert darr.time.pentad.ndays == 5
     assert darr.time.pentad.max_per_month == 6
 
+
 def test_labels_exception(darr):
     with pytest.raises(TypeError):
         _ = darr.x.labeler.dekad
+
 
 def test_period_exception(darr):
     with pytest.raises(TypeError):

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -120,10 +120,17 @@ def test_period_labels_pentad_single(darr):
     np.testing.assert_array_equal(darr.isel(time=0).time.pentad.label, ["200001p1"])
 
 
+def test_period_class_variables_dekad(darr):
+    assert darr.time.dekad.ndays == 10
+    assert darr.time.dekad.max_per_month == 3
+
+def test_period_class_variables_pentad(darr):
+    assert darr.time.pentad.ndays == 5
+    assert darr.time.pentad.max_per_month == 6
+
 def test_labels_exception(darr):
     with pytest.raises(TypeError):
         _ = darr.x.labeler.dekad
-
 
 def test_period_exception(darr):
     with pytest.raises(TypeError):


### PR DESCRIPTION
This PR

- changes the returned objects for properties `midx` and `yidx`  to `xarray.DataArray` so it can be used as is for `.groupby` operations (note that `.label` stays as `numpy.array`) - closes #14 
- changes the hidden class variables `_max_per_month` and `_ndays` to public so they can be used outside of the class / instance (c.f. https://github.com/WFP-VAM/seasmon-aws/pull/82#discussion_r795950675)