### PR TITLE
Fix `.label` return

### DIFF
--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -146,6 +146,7 @@ class Period(AccessorTimeBase):
             .str.cat(self.midx.astype("str"), sep=self._label)
         )
 
+
 @xarray.register_dataset_accessor("dekad")
 @xarray.register_dataarray_accessor("dekad")
 class Dekad(Period):

--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -312,7 +312,7 @@ class WhittakerSmoother:
         if sg is None and s is None:
             raise ValueError("Need S or sgrid")
 
-        lmda = 10 ** sg if sg is not None else s
+        lmda = 10**sg if sg is not None else s
 
         if p is not None:
 

--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -144,8 +144,7 @@ class Period(AccessorTimeBase):
             self.year.astype("str")
             .str.cat(self.month.astype("str").str.zfill(2))
             .str.cat(self.midx.astype("str"), sep=self._label)
-        ).values
-
+        )
 
 @xarray.register_dataset_accessor("dekad")
 @xarray.register_dataarray_accessor("dekad")

--- a/seasmon_xr/ops/autocorr.py
+++ b/seasmon_xr/ops/autocorr.py
@@ -86,7 +86,7 @@ def autocorr_1d_float(data):
     if var_X < 1e-8 or var_Y < 1e-8:
         return result
 
-    result = A * (var_X ** -0.5) * (var_Y ** -0.5)
+    result = A * (var_X**-0.5) * (var_Y**-0.5)
     return result
 
 
@@ -168,7 +168,7 @@ def autocorr_1d_int(data, nodata):
     if var_X < 1e-8 or var_Y < 1e-8:
         return result
 
-    result = A * (var_X ** -0.5) * (var_Y ** -0.5)
+    result = A * (var_X**-0.5) * (var_Y**-0.5)
     return result
 
 

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -484,7 +484,7 @@ def test_whit_whits_sg(darr):
 
     y = darr[:, 0, 0].astype("float64").data
     w = ((y != 0) * 1).astype("float64")
-    l = 10 ** -0.5
+    l = 10**-0.5
     z = np.rint(ws2d(y, l, w))
 
     np.testing.assert_array_equal(_darr[0, 0, :].data, z)
@@ -510,7 +510,7 @@ def test_whit_whits_sg_p(darr):
     np.testing.assert_array_equal(_darr, _res)
 
     y = darr[:, 0, 0].astype("float64").data
-    l = 10 ** -0.5
+    l = 10**-0.5
     z = np.rint(ops.ws2dpgu(y, l, 0, 0.90))
 
     np.testing.assert_array_equal(_darr[0, 0, :].data, z)

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -77,7 +77,7 @@ def test_labels_dekad(darr):
 
 
 def test_period_labels_dekad(darr):
-
+    assert isinstance(darr.time.dekad.label, xr.DataArray)
     np.testing.assert_array_equal(
         darr.time.dekad.label,
         ["200001d1", "200001d2", "200001d3", "200001d3", "200002d1"],
@@ -103,7 +103,7 @@ def test_labels_pentad(darr):
 
 
 def test_period_labels_pentad(darr):
-
+    assert isinstance(darr.time.pentad.label, xr.DataArray)
     np.testing.assert_array_equal(
         darr.time.pentad.label,
         ["200001p1", "200001p3", "200001p5", "200001p6", "200002p2"],


### PR DESCRIPTION
This PR changes the return value for `Period.label` from a `numpy.array` to be an `xarray.DataArray` which makes it easier to be used in `.groupby` operations (same as #14 )