### PR TITLE
Zonal statistics

### DIFF
--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -582,6 +582,21 @@ class ZonalStatistics(AccessorBase):
         dim_name: str = "zones",
         name: Optional[str] = None,
     ) -> xarray.DataArray:
+        """Calculate the zonal mean.
+
+        The mean for each pixel is calculated for each zone (group) in
+        `zones`.
+
+        The zones in the `zones` raster have to be numbered in a linear fashion,
+        starting with 0 for the first zone and num_zones for the last zone.
+
+        Args:
+            zones: zonal pixels (Y,X)
+            zone_ids: list or array with zone IDs (from 0 to (n-1))
+            dtype: datatype
+            dim_name: name for new output dimension
+            name: name for output dataarray
+        """
         from .ops.zonal import do_mean  # pylint: disable=import-outside-toplevel
 
         xx = self._obj

--- a/seasmon_xr/ops/zonal.py
+++ b/seasmon_xr/ops/zonal.py
@@ -1,0 +1,43 @@
+"""Numba accelerated zonal statistics."""
+from numba import njit
+from numpy import zeros
+
+from ._helper import lazycompile
+
+
+@lazycompile(njit)
+def do_mean(pixels, z_pixels, nodata, num_zones, dtype="float64"):
+    """Calculate the zonal mean.
+
+    The mean for each pixel of `pixels` is calculated for each zone in
+    `z_pixels`.
+
+    The zones in `z_pixels` have to be numbered in a linear fashion,
+    starting with 0 for the first zone and num_zones for the last zone.
+
+    Args:
+        pixels: input value pixels (T,Y,X)
+        z_pixels: zonal pixels (Y,X)
+        nodata: nodata value in values
+        num_zones: number of zones in z_pixels
+        dtype: datatype
+    """
+    t, nr, nc = pixels.shape
+
+    sums = zeros((t, num_zones), dtype=dtype)
+    valids = zeros((t, num_zones), dtype=dtype)
+
+    for tix in range(t):
+        for rw in range(nr):
+            for cl in range(nc):
+                pix = pixels[tix, rw, cl]
+                z_idx = z_pixels[rw, cl]
+                if pix != nodata and z_idx >= 0:
+                    sums[tix, z_idx] += pix
+                    valids[tix, z_idx] += 1
+
+        for idx in range(sums.shape[1]):
+            if valids[tix, idx] > 0:
+                sums[tix, idx] = sums[tix, idx] / valids[tix, idx]
+
+    return sums

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -15,8 +15,10 @@ from seasmon_xr.ops.ws2d import ws2d
 def darr():
     np.random.seed(42)
     x = xr.DataArray(
-        np.random.randint(1, 100, (5, 2, 2)), dims=("time", "y", "x"), name="band",
-        attrs={"nodata": -9999}
+        np.random.randint(1, 100, (5, 2, 2)),
+        dims=("time", "y", "x"),
+        name="band",
+        attrs={"nodata": -9999},
     )
     x["time"] = pd.date_range(start="2000-01-01", periods=5, freq="10D")
 
@@ -32,13 +34,13 @@ def res_spi():
         ]
     )
 
+
 @pytest.fixture
 def zones():
-    x = xr.DataArray(
-        [[0, 1], [0, 1]], dims=("y", "x"), name="band"
-    )
+    x = xr.DataArray([[0, 1], [0, 1]], dims=("y", "x"), name="band")
 
     return x
+
 
 def test_period_years_dekad(darr):
     np.testing.assert_array_equal(darr.time.dekad.year, darr.time.dt.year)
@@ -775,29 +777,23 @@ def test_whit_exception(darr):
     with pytest.raises(ValueError):
         _ = darr.isel(time=0).whit
 
+
 def test_zonal_mean(darr, zones):
     res = np.array(
-       [[33.5, 82.5],
-       [72., 54.],
-       [81.5, 49.5],
-       [28., 12.],
-       [63., 16.]],
-       dtype="float64"
+        [[33.5, 82.5], [72.0, 54.0], [81.5, 49.5], [28.0, 12.0], [63.0, 16.0]],
+        dtype="float64",
     )
 
     z_ids = np.unique(zones.data)
     x = darr.zonal.mean(zones, z_ids)
     np.testing.assert_almost_equal(x, res)
 
+
 def test_zonal_mean_nodata(darr, zones):
 
     res = np.array(
-       [[15., 82.5],
-       [72., 54.],
-       [81.5, 49.5],
-       [28., 12.],
-       [63., 16.]],
-       dtype="float64"
+        [[15.0, 82.5], [72.0, 54.0], [81.5, 49.5], [28.0, 12.0], [63.0, 16.0]],
+        dtype="float64",
     )
 
     darr[0, 0, 0] = darr.nodata
@@ -806,16 +802,19 @@ def test_zonal_mean_nodata(darr, zones):
     x = darr.zonal.mean(zones, z_ids)
     np.testing.assert_almost_equal(x, res)
 
+
 def test_zonal_dimname(darr, zones):
     z_ids = np.unique(zones.data)
     x = darr.zonal.mean(zones, z_ids, dim_name="foo")
     assert x.dims == ("time", "foo")
+
 
 def test_zonal_nodata_exc(darr, zones):
     z_ids = np.unique(zones.data)
     del darr.attrs["nodata"]
     with pytest.raises(ValueError):
         _ = darr.zonal.mean(zones, z_ids)
+
 
 def test_zonal_type_exc(darr, zones):
     z_ids = np.unique(zones.data)


### PR DESCRIPTION
This PR adds an `xarray` accessor and the relevant functions for calculating zonal statistics (currently only mean).

This is connected to https://github.com/WFP-VAM/seasmon-aws/issues/102 with the idea that the base functions for calculating zonal statistics would fit better here and then be used in ops in seasmon-aws.

@Kirill888 please see additional comments in review