### PR TITLE
Add `.hdc` 'parent' accessor

### DIFF
--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -569,6 +569,7 @@ class PixelAlgorithms:
             output_dtypes=["float32"],
         )
 
+
 @xarray.register_dataset_accessor("zonal")
 @xarray.register_dataarray_accessor("zonal")
 class ZonalStatistics(AccessorBase):
@@ -647,6 +648,8 @@ class ZonalStatistics(AccessorBase):
 @xarray.register_dataset_accessor("hdc")
 @xarray.register_dataarray_accessor("hdc")
 class HDC:
+    """xarray accessor for HDC xarray tools."""
+
     def __init__(self, xarray_obj):
         self.algo = PixelAlgorithms(xarray_obj)
         self.anom = Anomalies(xarray_obj)

--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -602,6 +602,9 @@ class ZonalStatistics(AccessorBase):
 
         xx = self._obj
 
+        if isinstance(xx, xarray.Dataset):
+            raise NotImplementedError("zonal needs dataarray as input")
+
         if "nodata" not in xx.attrs:
             raise ValueError("Input xarray DataArray needs nodata attribute")
 

--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -569,7 +569,7 @@ class PixelAlgorithms:
             output_dtypes=["float32"],
         )
 
-
+@xarray.register_dataset_accessor("zonal")
 @xarray.register_dataarray_accessor("zonal")
 class ZonalStatistics(AccessorBase):
     """Class to claculate zonal statistics."""
@@ -642,3 +642,14 @@ class ZonalStatistics(AccessorBase):
         return xarray.DataArray(
             data=data, dims=dims, coords=coords, attrs={}, name=name
         )
+
+
+@xarray.register_dataset_accessor("hdc")
+@xarray.register_dataarray_accessor("hdc")
+class HDC:
+    def __init__(self, xarray_obj):
+        self.algo = PixelAlgorithms(xarray_obj)
+        self.anom = Anomalies(xarray_obj)
+        self.iteragg = IterativeAggregation(xarray_obj)
+        self.whit = WhittakerSmoother(xarray_obj)
+        self.zonal = ZonalStatistics(xarray_obj)

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -829,6 +829,3 @@ def test_zonal_type_exc(darr, zones):
     z_ids = np.unique(zones.data)
     with pytest.raises(ValueError):
         _ = darr.zonal.mean(zones.data, z_ids)
-
-## compat tests
-

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -829,3 +829,6 @@ def test_zonal_type_exc(darr, zones):
     z_ids = np.unique(zones.data)
     with pytest.raises(ValueError):
         _ = darr.zonal.mean(zones.data, z_ids)
+
+## compat tests
+


### PR DESCRIPTION
This PR add the `.hdc` accessor that will group most other accessors under it.

In this versions, the accessors are accessible both ways, i.e. `xx.algo.spi` and `xx.hdc.algo.spi` because they are being used in ops.

Notable exceptions to the `hdc` accessor are the `time.dekad` and `time.pentad` accessors as well as the (soon to be deprecated) `.labeler` accessor. I would say these can remain as is because they are more an extension to the `time` dimension similar to the `dt` accessor.



Closes #18 