### PR TITLE
Remove old accessor references and add better time dim check + tests

### DIFF
--- a/seasmon_xr/__init__.py
+++ b/seasmon_xr/__init__.py
@@ -5,7 +5,6 @@ from ._version import __version__
 from .accessors import (
     Anomalies,
     IterativeAggregation,
-    LabelMaker,
     PixelAlgorithms,
     WhittakerSmoother,
 )
@@ -13,7 +12,6 @@ from .accessors import (
 __all__ = (
     "Anomalies",
     "IterativeAggregation",
-    "LabelMaker",
     "PixelAlgorithms",
     "WhittakerSmoother",
     "__version__",

--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -14,7 +14,6 @@ __all__ = [
     "Anomalies",
     "Dekad",
     "IterativeAggregation",
-    "LabelMaker",
     "Pentad",
     "PixelAlgorithms",
     "WhittakerSmoother",
@@ -59,59 +58,6 @@ class AccessorTimeBase(AccessorBase):
     @property
     def day(self):
         return self._obj.time.dt.day
-
-
-@xarray.register_dataarray_accessor("labeler")
-class LabelMaker:
-    """
-    Class to extending xarray.Dataarray for 'time'.
-
-    Adds the properties labelling the time values as either
-    dekads or pentads.
-    """
-
-    def __init__(self, xarray_obj):
-        """Construct with DataArray|Dataset."""
-        if not np.issubdtype(xarray_obj, np.datetime64):
-            raise TypeError(
-                "'.labeler' accessor only available for "
-                "DataArray with datetime64 dtype"
-            )
-
-        if not hasattr(xarray_obj, "time"):
-            raise ValueError("Data array is missing 'time' accessor!")
-
-        if "time" not in xarray_obj.dims:
-            xarray_obj = xarray_obj.expand_dims("time")
-        self._obj = xarray_obj
-
-    @property
-    def dekad(self):
-        """Time values labeled as dekads."""
-        return (
-            self._obj.time.to_series()
-            .apply(
-                func=self._gen_labels,
-                args=("d", 10.5),
-            )
-            .values
-        )
-
-    @property
-    def pentad(self):
-        """Time values labeled as pentads."""
-        return (
-            self._obj.time.to_series()
-            .apply(
-                func=self._gen_labels,
-                args=("p", 5.19),
-            )
-            .values
-        )
-
-    @staticmethod
-    def _gen_labels(x, lbl, c):
-        return f"{x.year}{x.month:02}" + f"{lbl}{int(x.day//c+1)}"
 
 
 class Period(AccessorTimeBase):

--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -113,9 +113,6 @@ class Pentad(Period):
     max_per_month = 6
     _label = "p"
 
-
-@xarray.register_dataset_accessor("iteragg")
-@xarray.register_dataarray_accessor("iteragg")
 class IterativeAggregation(AccessorBase):
     """Class to aggregate multiple coordinate slices."""
 
@@ -204,9 +201,6 @@ class IterativeAggregation(AccessorBase):
 
                 yield _obj
 
-
-@xarray.register_dataset_accessor("anom")
-@xarray.register_dataarray_accessor("anom")
 class Anomalies(AccessorBase):
     """Class to calculate anomalies from reference."""
 
@@ -218,9 +212,6 @@ class Anomalies(AccessorBase):
         """Calculate anomaly as difference."""
         return (self._obj + offset) - (reference + offset)
 
-
-@xarray.register_dataset_accessor("whit")
-@xarray.register_dataarray_accessor("whit")
 class WhittakerSmoother:
     """Class for applying different version of the Whittaker smoother."""
 
@@ -389,9 +380,6 @@ class WhittakerSmoother:
 
         return ds_out
 
-
-@xarray.register_dataset_accessor("algo")
-@xarray.register_dataarray_accessor("algo")
 class PixelAlgorithms:
     """Set of algorithms to be applied to pixel timeseries."""
 
@@ -515,9 +503,6 @@ class PixelAlgorithms:
             output_dtypes=["float32"],
         )
 
-
-@xarray.register_dataset_accessor("zonal")
-@xarray.register_dataarray_accessor("zonal")
 class ZonalStatistics(AccessorBase):
     """Class to claculate zonal statistics."""
 

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -78,14 +78,6 @@ def test_period_yidx_pentad(darr):
     np.testing.assert_array_equal(darr.time.pentad.yidx, [1, 3, 5, 6, 8])
 
 
-def test_labels_dekad(darr):
-
-    np.testing.assert_array_equal(
-        darr.time.labeler.dekad,
-        ["200001d1", "200001d2", "200001d3", "200001d3", "200002d1"],
-    )
-
-
 def test_period_labels_dekad(darr):
     assert isinstance(darr.time.dekad.label, xr.DataArray)
     np.testing.assert_array_equal(
@@ -94,22 +86,9 @@ def test_period_labels_dekad(darr):
     )
 
 
-def test_labels_dekad_single(darr):
-
-    np.testing.assert_array_equal(darr.isel(time=0).time.labeler.dekad, ["200001d1"])
-
-
 def test_period_labels_dekad_single(darr):
 
     np.testing.assert_array_equal(darr.isel(time=0).time.dekad.label, ["200001d1"])
-
-
-def test_labels_pentad(darr):
-
-    np.testing.assert_array_equal(
-        darr.time.labeler.pentad,
-        ["200001p1", "200001p3", "200001p5", "200001p6", "200002p2"],
-    )
 
 
 def test_period_labels_pentad(darr):
@@ -118,12 +97,6 @@ def test_period_labels_pentad(darr):
         darr.time.pentad.label,
         ["200001p1", "200001p3", "200001p5", "200001p6", "200002p2"],
     )
-
-
-def test_labels_pentad_single(darr):
-
-    np.testing.assert_array_equal(darr.isel(time=0).time.labeler.pentad, ["200001p1"])
-
 
 def test_period_labels_pentad_single(darr):
 
@@ -138,11 +111,6 @@ def test_period_class_variables_dekad(darr):
 def test_period_class_variables_pentad(darr):
     assert darr.time.pentad.ndays == 5
     assert darr.time.pentad.max_per_month == 6
-
-
-def test_labels_exception(darr):
-    with pytest.raises(TypeError):
-        _ = darr.x.labeler.dekad
 
 
 def test_period_exception(darr):

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -121,7 +121,7 @@ def test_period_exception(darr):
 def test_algo_lroo(darr):
     _res = np.array([[3, 0], [4, 2]], dtype="uint8")
 
-    darr_lroo = ((darr > 30) * 1).astype("uint8").algo.lroo()
+    darr_lroo = ((darr > 30) * 1).astype("uint8").hdc.algo.lroo()
     assert isinstance(darr_lroo, xr.DataArray)
     np.testing.assert_array_equal(darr_lroo, _res)
 
@@ -129,7 +129,7 @@ def test_algo_lroo(darr):
 def test_algo_croo(darr):
     _res = np.array([[1, 0], [4, 0]], dtype="uint8")
 
-    darr_croo = ((darr > 30) * 1).algo.croo()
+    darr_croo = ((darr > 30) * 1).hdc.algo.croo()
     assert isinstance(darr_croo, xr.DataArray)
     np.testing.assert_array_equal(darr_croo, _res)
 
@@ -138,56 +138,56 @@ def test_anom_ratio(darr):
     _res = np.array([[85.0, 443.0], [18.0, 83.0]])
 
     np.testing.assert_array_equal(
-        darr.isel(time=0).anom.ratio(darr.isel(time=1)).round(), _res
+        darr.isel(time=0).hdc.anom.ratio(darr.isel(time=1)).round(), _res
     )
 
 
 def test_anom_diff(darr):
     _res = np.array([[-9, 72], [-68, -15]])
 
-    np.testing.assert_array_equal(darr.isel(time=0).anom.diff(darr.isel(time=1)), _res)
+    np.testing.assert_array_equal(darr.isel(time=0).hdc.anom.diff(darr.isel(time=1)), _res)
 
 
 def test_algo_autocorr(darr):
     _res = np.array(
         [[-0.7395127, -0.69477093], [-0.1768683, 0.6412078]], dtype="float32"
     )
-    darr_autocorr = darr.algo.autocorr()
+    darr_autocorr = darr.hdc.algo.autocorr()
     assert isinstance(darr_autocorr, xr.DataArray)
     np.testing.assert_almost_equal(darr_autocorr, _res)
 
 
 def test_algo_spi(darr, res_spi):
-    _res = darr.algo.spi()
+    _res = darr.hdc.algo.spi()
     assert isinstance(_res, xr.DataArray)
     np.testing.assert_array_equal(_res, res_spi)
 
 
 def test_algo_spi_transp(darr, res_spi):
     _darr = darr.transpose(..., "time")
-    _res = _darr.algo.spi()
+    _res = _darr.hdc.algo.spi()
     assert isinstance(_res, xr.DataArray)
     np.testing.assert_array_equal(_res, res_spi)
 
 
 def test_algo_spi_attrs_default(darr):
-    _res = darr.algo.spi()
+    _res = darr.hdc.algo.spi()
     assert _res.attrs["spi_calibration_start"] == str(darr.time.dt.date[0].values)
     assert _res.attrs["spi_calibration_stop"] == str(darr.time.dt.date[-1].values)
 
 
 def test_algo_spi_attrs_start(darr):
-    _res = darr.algo.spi(calibration_start="2000-01-02")
+    _res = darr.hdc.algo.spi(calibration_start="2000-01-02")
     assert _res.attrs["spi_calibration_start"] == "2000-01-11"
 
 
 def test_algo_spi_attrs_stop(darr):
-    _res = darr.algo.spi(calibration_stop="2000-02-09")
+    _res = darr.hdc.algo.spi(calibration_stop="2000-02-09")
     assert _res.attrs["spi_calibration_stop"] == "2000-01-31"
 
 
 def test_algo_spi_decoupled_1(darr, res_spi):
-    _res = darr.algo.spi(calibration_start="2000-01-01", calibration_stop="2000-02-10")
+    _res = darr.hdc.algo.spi(calibration_start="2000-01-01", calibration_stop="2000-02-10")
 
     assert isinstance(_res, xr.DataArray)
     np.testing.assert_array_equal(_res, res_spi)
@@ -204,7 +204,7 @@ def test_algo_spi_decoupled_2(darr):
         ]
     )
 
-    _res = darr.algo.spi(calibration_start="2000-01-01", calibration_stop="2000-01-31")
+    _res = darr.hdc.algo.spi(calibration_start="2000-01-01", calibration_stop="2000-01-31")
 
     assert isinstance(_res, xr.DataArray)
     np.testing.assert_array_equal(_res, res_spi)
@@ -221,7 +221,7 @@ def test_algo_spi_decoupled_3(darr):
         ]
     )
 
-    _res = darr.algo.spi(calibration_start="2000-01-11")
+    _res = darr.hdc.algo.spi(calibration_start="2000-01-11")
 
     assert isinstance(_res, xr.DataArray)
     np.testing.assert_array_equal(_res, res_spi)
@@ -232,21 +232,21 @@ def test_algo_spi_decoupled_3(darr):
 
 def test_algo_spi_decoupled_err_1(darr):
     with pytest.raises(ValueError):
-        _res = darr.algo.spi(
+        _res = darr.hdc.algo.spi(
             calibration_start="2000-03-01",
         )
 
 
 def test_algo_spi_decoupled_err_2(darr):
     with pytest.raises(ValueError):
-        _res = darr.algo.spi(
+        _res = darr.hdc.algo.spi(
             calibration_stop="1999-01-01",
         )
 
 
 def test_algo_spi_decoupled_err_3(darr):
     with pytest.raises(ValueError):
-        _res = darr.algo.spi(
+        _res = darr.hdc.algo.spi(
             calibration_start="2000-01-01",
             calibration_stop="2000-01-01",
         )
@@ -254,7 +254,7 @@ def test_algo_spi_decoupled_err_3(darr):
 
 def test_algo_spi_decoupled_err_4(darr):
     with pytest.raises(ValueError):
-        _res = darr.algo.spi(
+        _res = darr.hdc.algo.spi(
             calibration_start="2000-02-01",
             calibration_stop="2000-01-01",
         )
@@ -262,13 +262,13 @@ def test_algo_spi_decoupled_err_4(darr):
 
 def test_algo_exception(darr):
     with pytest.raises(ValueError):
-        _ = darr.isel(time=0).algo
+        _ = darr.isel(time=0).hdc.algo
 
 
 def test_agg_sum_1(darr):
     n = 0
     ii = -1
-    for _x in darr.iteragg.sum(1):
+    for _x in darr.hdc.iteragg.sum(1):
         np.testing.assert_array_equal(_x.squeeze(), darr[ii, :])
         assert _x.attrs["agg_n"] == 1
         assert _x.time == darr.time[ii]
@@ -280,7 +280,7 @@ def test_agg_sum_1_lim_begin(darr):
     n = 0
     begin = "2000-01-21"
     ii = darr.time.to_index().get_loc(begin)
-    for _x in darr.iteragg.sum(1, begin=begin):
+    for _x in darr.hdc.iteragg.sum(1, begin=begin):
         np.testing.assert_array_equal(_x.squeeze(), darr[ii, :])
         assert _x.attrs["agg_n"] == 1
         assert _x.time == darr.time[ii]
@@ -294,7 +294,7 @@ def test_agg_sum_1_lim_end(darr):
     end = "2000-01-21"
     ii = -1
     _last_x = None
-    for _x in darr.iteragg.sum(1, end=end):
+    for _x in darr.hdc.iteragg.sum(1, end=end):
         np.testing.assert_array_equal(_x.squeeze(), darr[ii, :])
         assert _x.attrs["agg_n"] == 1
         assert _x.time == darr.time[ii]
@@ -312,7 +312,7 @@ def test_agg_sum_1_lim_begin_end(darr):
     end = "2000-01-11"
     ii = darr.time.to_index().get_loc(begin)
     _last_x = None
-    for _x in darr.iteragg.sum(1, begin=begin, end=end):
+    for _x in darr.hdc.iteragg.sum(1, begin=begin, end=end):
         np.testing.assert_array_equal(_x.squeeze(), darr[ii, :])
         assert _x.attrs["agg_n"] == 1
         assert _x.time == darr.time[ii]
@@ -327,7 +327,7 @@ def test_agg_sum_1_lim_begin_end(darr):
 
 def test_agg_sum_3(darr):
     n = 0
-    for _x in darr.iteragg.sum(n=3):
+    for _x in darr.hdc.iteragg.sum(n=3):
         np.testing.assert_array_equal(
             _x.squeeze(),
             darr.sel(time=slice(_x.attrs["agg_start"], _x.attrs["agg_stop"])).sum(
@@ -343,7 +343,7 @@ def test_agg_sum_3(darr):
 def test_agg_mean_1(darr):
     n = 0
     ii = -1
-    for _x in darr.iteragg.mean(1):
+    for _x in darr.hdc.iteragg.mean(1):
         np.testing.assert_array_equal(_x.squeeze(), darr[ii, :])
         assert _x.attrs["agg_n"] == 1
         assert _x.time == darr.time[ii]
@@ -356,7 +356,7 @@ def test_agg_mean_1_lim_begin(darr):
     n = 0
     begin = "2000-01-21"
     ii = darr.time.to_index().get_loc(begin)
-    for _x in darr.iteragg.mean(1, begin=begin):
+    for _x in darr.hdc.iteragg.mean(1, begin=begin):
         np.testing.assert_array_equal(_x.squeeze(), darr[ii, :])
         assert _x.attrs["agg_n"] == 1
         assert _x.time == darr.time[ii]
@@ -370,7 +370,7 @@ def test_agg_mean_1_lim_end(darr):
     end = "2000-01-21"
     ii = -1
     _last_x = None
-    for _x in darr.iteragg.mean(1, end=end):
+    for _x in darr.hdc.iteragg.mean(1, end=end):
         np.testing.assert_array_equal(_x.squeeze(), darr[ii, :])
         assert _x.attrs["agg_n"] == 1
         assert _x.time == darr.time[ii]
@@ -388,7 +388,7 @@ def test_agg_mean_1_lim_begin_end(darr):
     end = "2000-01-11"
     ii = darr.time.to_index().get_loc(begin)
     _last_x = None
-    for _x in darr.iteragg.mean(1, begin=begin, end=end):
+    for _x in darr.hdc.iteragg.mean(1, begin=begin, end=end):
         np.testing.assert_array_equal(_x.squeeze(), darr[ii, :])
         assert _x.attrs["agg_n"] == 1
         assert _x.time == darr.time[ii]
@@ -402,7 +402,7 @@ def test_agg_mean_1_lim_begin_end(darr):
 
 def test_agg_mean_3(darr):
     n = 0
-    for _x in darr.iteragg.mean(3):
+    for _x in darr.hdc.iteragg.mean(3):
         np.testing.assert_array_equal(
             _x.squeeze(),
             darr.sel(time=slice(_x.attrs["agg_start"], _x.attrs["agg_stop"])).mean(
@@ -417,7 +417,7 @@ def test_agg_mean_3(darr):
 
 def test_agg_full_3(darr):
     n = 0
-    for _x in darr.iteragg.full(3):
+    for _x in darr.hdc.iteragg.full(3):
         np.testing.assert_array_equal(
             _x.squeeze(),
             darr.sel(time=slice(_x.attrs["agg_start"], _x.attrs["agg_stop"])),
@@ -438,7 +438,7 @@ def test_whit_whits_s(darr):
         ],
         dtype="int16",
     )
-    _darr = darr.whit.whits(nodata=0, s=10)
+    _darr = darr.hdc.whit.whits(nodata=0, s=10)
     np.testing.assert_array_equal(_darr, _res)
 
     y = darr[:, 0, 0].astype("float64").data
@@ -457,7 +457,7 @@ def test_whit_whits_sg(darr):
         ],
         dtype="int16",
     )
-    _darr = darr.whit.whits(nodata=0, sg=sg)
+    _darr = darr.hdc.whit.whits(nodata=0, sg=sg)
     np.testing.assert_array_equal(_darr, _res)
 
     y = darr[:, 0, 0].astype("float64").data
@@ -471,7 +471,7 @@ def test_whit_whits_sg(darr):
 def test_whit_whits_sg_zeros(darr):
     sg = np.full((2, 2), -np.inf)
     _res = darr.transpose(..., "time")
-    _darr = darr.whit.whits(nodata=0, sg=sg)
+    _darr = darr.hdc.whit.whits(nodata=0, sg=sg)
     np.testing.assert_array_equal(_darr, _res)
 
 
@@ -484,7 +484,7 @@ def test_whit_whits_sg_p(darr):
         ],
         dtype="int16",
     )
-    _darr = darr.whit.whits(nodata=0, sg=sg, p=0.90)
+    _darr = darr.hdc.whit.whits(nodata=0, sg=sg, p=0.90)
     np.testing.assert_array_equal(_darr, _res)
 
     y = darr[:, 0, 0].astype("float64").data
@@ -497,7 +497,7 @@ def test_whit_whits_sg_p(darr):
 def test_whit_whits_sg_p_zeros(darr):
     sg = np.full((2, 2), -np.inf)
     _res = darr.transpose(..., "time")
-    _darr = darr.whit.whits(nodata=0, sg=sg, p=0.90)
+    _darr = darr.hdc.whit.whits(nodata=0, sg=sg, p=0.90)
     np.testing.assert_array_equal(_darr, _res)
 
 
@@ -510,7 +510,7 @@ def test_whit_whitsvc(darr):
         ],
         dtype="int16",
     )
-    _darr = darr.whit.whitsvc(nodata=0, srange=srange)
+    _darr = darr.hdc.whit.whitsvc(nodata=0, srange=srange)
     assert isinstance(_darr, xr.Dataset)
     assert "band" in _darr
     assert "sgrid" in _darr
@@ -537,7 +537,7 @@ def test_whit_whitsvc_unnamed(darr):
     )
 
     darr.name = None
-    _darr = darr.whit.whitsvc(nodata=0, srange=srange)
+    _darr = darr.hdc.whit.whitsvc(nodata=0, srange=srange)
     assert isinstance(_darr, xr.Dataset)
     assert "band" in _darr
     assert "sgrid" in _darr
@@ -562,7 +562,7 @@ def test_whit_whitsvcp(darr):
         ],
         dtype="int16",
     )
-    _darr = darr.whit.whitsvc(nodata=0, srange=srange, p=0.90)
+    _darr = darr.hdc.whit.whitsvc(nodata=0, srange=srange, p=0.90)
     assert isinstance(_darr, xr.Dataset)
     assert "band" in _darr
     assert "sgrid" in _darr
@@ -589,7 +589,7 @@ def test_whit_whitsvcp_unnamed(darr):
     )
 
     darr.name = None
-    _darr = darr.whit.whitsvc(nodata=0, srange=srange, p=0.90)
+    _darr = darr.hdc.whit.whitsvc(nodata=0, srange=srange, p=0.90)
     assert isinstance(_darr, xr.Dataset)
     assert "band" in _darr
     assert "sgrid" in _darr
@@ -720,7 +720,7 @@ def test_whit_whitint(darr):
     )
 
     temp = template.copy()
-    res = darr.astype("int16").whit.whitint(labels_daily, temp)
+    res = darr.astype("int16").hdc.whit.whitint(labels_daily, temp)
     assert "newtime" in res.dims
     assert res.newtime.size == 5
 
@@ -743,7 +743,7 @@ def test_whit_whitint(darr):
 
 def test_whit_exception(darr):
     with pytest.raises(ValueError):
-        _ = darr.isel(time=0).whit
+        _ = darr.isel(time=0).hdc.whit
 
 
 def test_zonal_mean(darr, zones):
@@ -753,7 +753,7 @@ def test_zonal_mean(darr, zones):
     )
 
     z_ids = np.unique(zones.data)
-    x = darr.zonal.mean(zones, z_ids)
+    x = darr.hdc.zonal.mean(zones, z_ids)
     np.testing.assert_almost_equal(x, res)
 
 
@@ -767,7 +767,7 @@ def test_zonal_mean_nodata(darr, zones):
     darr[0, 0, 0] = darr.nodata
 
     z_ids = np.unique(zones.data)
-    x = darr.zonal.mean(zones, z_ids)
+    x = darr.hdc.zonal.mean(zones, z_ids)
     np.testing.assert_almost_equal(x, res)
 
 
@@ -776,13 +776,13 @@ def test_zonal_mean_nodata_nan(darr, zones):
     darr[[0, -1], :] = darr.nodata
 
     z_ids = np.unique(zones.data)
-    x = darr.zonal.mean(zones, z_ids)
+    x = darr.hdc.zonal.mean(zones, z_ids)
     assert np.isnan(x.data[[0, -1], :]).all()
 
 
 def test_zonal_dimname(darr, zones):
     z_ids = np.unique(zones.data)
-    x = darr.zonal.mean(zones, z_ids, dim_name="foo")
+    x = darr.hdc.zonal.mean(zones, z_ids, dim_name="foo")
     assert x.dims == ("time", "foo")
 
 
@@ -790,10 +790,10 @@ def test_zonal_nodata_exc(darr, zones):
     z_ids = np.unique(zones.data)
     del darr.attrs["nodata"]
     with pytest.raises(ValueError):
-        _ = darr.zonal.mean(zones, z_ids)
+        _ = darr.hdc.zonal.mean(zones, z_ids)
 
 
 def test_zonal_type_exc(darr, zones):
     z_ids = np.unique(zones.data)
     with pytest.raises(ValueError):
-        _ = darr.zonal.mean(zones.data, z_ids)
+        _ = darr.hdc.zonal.mean(zones.data, z_ids)

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -8,6 +8,7 @@ import pytest
 import xarray as xr
 
 from seasmon_xr import ops
+from seasmon_xr.accessors import MissingTimeError
 from seasmon_xr.ops.ws2d import ws2d
 
 
@@ -98,6 +99,7 @@ def test_period_labels_pentad(darr):
         ["200001p1", "200001p3", "200001p5", "200001p6", "200002p2"],
     )
 
+
 def test_period_labels_pentad_single(darr):
 
     np.testing.assert_array_equal(darr.isel(time=0).time.pentad.label, ["200001p1"])
@@ -145,7 +147,9 @@ def test_anom_ratio(darr):
 def test_anom_diff(darr):
     _res = np.array([[-9, 72], [-68, -15]])
 
-    np.testing.assert_array_equal(darr.isel(time=0).hdc.anom.diff(darr.isel(time=1)), _res)
+    np.testing.assert_array_equal(
+        darr.isel(time=0).hdc.anom.diff(darr.isel(time=1)), _res
+    )
 
 
 def test_algo_autocorr(darr):
@@ -187,7 +191,9 @@ def test_algo_spi_attrs_stop(darr):
 
 
 def test_algo_spi_decoupled_1(darr, res_spi):
-    _res = darr.hdc.algo.spi(calibration_start="2000-01-01", calibration_stop="2000-02-10")
+    _res = darr.hdc.algo.spi(
+        calibration_start="2000-01-01", calibration_stop="2000-02-10"
+    )
 
     assert isinstance(_res, xr.DataArray)
     np.testing.assert_array_equal(_res, res_spi)
@@ -204,7 +210,9 @@ def test_algo_spi_decoupled_2(darr):
         ]
     )
 
-    _res = darr.hdc.algo.spi(calibration_start="2000-01-01", calibration_stop="2000-01-31")
+    _res = darr.hdc.algo.spi(
+        calibration_start="2000-01-01", calibration_stop="2000-01-31"
+    )
 
     assert isinstance(_res, xr.DataArray)
     np.testing.assert_array_equal(_res, res_spi)
@@ -260,9 +268,19 @@ def test_algo_spi_decoupled_err_4(darr):
         )
 
 
-def test_algo_exception(darr):
-    with pytest.raises(ValueError):
-        _ = darr.isel(time=0).hdc.algo
+def test_algo_spi_exception(darr):
+    with pytest.raises(MissingTimeError):
+        _ = darr.isel(time=0).hdc.algo.spi()
+
+
+def test_algo_croo_exception(darr):
+    with pytest.raises(MissingTimeError):
+        _ = darr.isel(time=0).hdc.algo.croo()
+
+
+def test_algo_lroo_exception(darr):
+    with pytest.raises(MissingTimeError):
+        _ = darr.isel(time=0).hdc.algo.lroo()
 
 
 def test_agg_sum_1(darr):
@@ -741,9 +759,19 @@ def test_whit_whitint(darr):
     np.testing.assert_array_equal(res[0, 0, :], xx_int.data.values)
 
 
-def test_whit_exception(darr):
-    with pytest.raises(ValueError):
-        _ = darr.isel(time=0).hdc.whit
+def test_whit_whits_exception(darr):
+    with pytest.raises(MissingTimeError):
+        _ = darr.isel(time=0).hdc.whit.whits(nodata=-3000)
+
+
+def test_whit_whitsvc_exception(darr):
+    with pytest.raises(MissingTimeError):
+        _ = darr.isel(time=0).hdc.whit.whitsvc(nodata=-3000)
+
+
+def test_whit_whitint_exception(darr):
+    with pytest.raises(MissingTimeError):
+        _ = darr.isel(time=0).hdc.whit.whitint(None, None)
 
 
 def test_zonal_mean(darr, zones):


### PR DESCRIPTION
This PR

- removes the `LabelMaker` class (functionally replaced by `Period`)
- removes old accessor registrations (all moved to `.hdc` now)
- adds a way to deal with missing time dimension at function execution level rather than at class instantiation

For the last point, an exception class is introduced `MissingTimeError` and a hidden instance method `_check_for_timedim` to the `AccessorBase` class which inherits to the different accessor classes.

When required, `_check_for_timedim` returns `True`/`False` depending on if "time" is in dimensions, and a `MissingTimeError` is raised accordingly.