### PR TITLE
Improve nodata handling in zonal

### DIFF
--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -561,7 +561,7 @@ class ZonalStatistics(AccessorBase):
             raise ValueError("Zones xarray DataArray needs nodata attribute")
 
         # set null values to nodata value
-        xx = xx.where(~xx.isnull(), xx.nodata).astype(xx.dtype)
+        xx = xx.where(xx.notnull(), xx.nodata)
 
         num_zones = len(zone_ids)
         dims = (xx.dims[0], dim_name)

--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -560,6 +560,9 @@ class ZonalStatistics(AccessorBase):
         if "nodata" not in zones.attrs:
             raise ValueError("Zones xarray DataArray needs nodata attribute")
 
+        # set null values to nodata value
+        xx = xx.where(~xx.isnull(), xx.nodata).astype(xx.dtype)
+
         num_zones = len(zone_ids)
         dims = (xx.dims[0], dim_name)
         coords = {dims[0]: xx.coords[dims[0]], dim_name: zone_ids}

--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -611,6 +611,9 @@ class ZonalStatistics(AccessorBase):
         if not isinstance(zones, xarray.DataArray):
             raise ValueError("Zones need to be xarray.DataArray!")
 
+        if "nodata" not in zones.attrs:
+            raise ValueError("Zones xarray DataArray needs nodata attribute")
+
         num_zones = len(zone_ids)
         dims = (xx.dims[0], dim_name)
         coords = {dims[0]: xx.coords[dims[0]], dim_name: zone_ids}
@@ -626,8 +629,9 @@ class ZonalStatistics(AccessorBase):
                 do_mean,
                 xx.data,
                 zones.data,
-                xx.nodata,
                 num_zones,
+                xx.nodata,
+                zones.nodata,
                 drop_axis=[1, 2],
                 new_axis=1,
                 chunks=chunks,
@@ -639,8 +643,9 @@ class ZonalStatistics(AccessorBase):
             data = do_mean(
                 xx.data,
                 zones.data,
-                xx.nodata,
                 num_zones,
+                xx.nodata,
+                zones.nodata,
             )
 
         return xarray.DataArray(

--- a/seasmon_xr/ops/zonal.py
+++ b/seasmon_xr/ops/zonal.py
@@ -6,7 +6,7 @@ from ._helper import lazycompile
 
 
 @lazycompile(njit)
-def do_mean(pixels, z_pixels, nodata, num_zones, dtype="float64"):
+def do_mean(pixels, z_pixels, num_zones, nodata, z_nodata, dtype="float64"):
     """Calculate the zonal mean.
 
     The mean for each pixel of `pixels` is calculated for each zone in
@@ -32,7 +32,7 @@ def do_mean(pixels, z_pixels, nodata, num_zones, dtype="float64"):
             for cl in range(nc):
                 pix = pixels[tix, rw, cl]
                 z_idx = z_pixels[rw, cl]
-                if pix != nodata and z_idx >= 0:
+                if (pix != nodata) and (z_idx != z_nodata):
                     sums[tix, z_idx] += pix
                     valids[tix, z_idx] += 1
 

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -810,6 +810,21 @@ def test_zonal_mean_nodata_nan(darr, zones):
     assert np.isnan(x.data[[0, -1], :]).all()
 
 
+def test_zonal_mean_nodata_nan_float(darr, zones):
+
+    res = np.array(
+        [[15.0, 82.5], [72.0, 54.0], [81.5, 49.5], [28.0, 12.0], [63.0, 16.0]],
+        dtype="float64",
+    )
+
+    darr = darr.astype("float64")
+    darr[0, 0, 0] = "nan"
+
+    z_ids = np.unique(zones.data)
+    x = darr.hdc.zonal.mean(zones, z_ids)
+    np.testing.assert_almost_equal(x, res)
+
+
 def test_zonal_zone_nodata_nan(darr, zones):
 
     res = np.array(

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -37,7 +37,9 @@ def res_spi():
 
 @pytest.fixture
 def zones():
-    x = xr.DataArray([[0, 1], [0, 1]], dims=("y", "x"), name="band")
+    x = xr.DataArray(
+        [[0, 1], [0, 1]], dims=("y", "x"), name="band", attrs={"nodata": -1}
+    )
 
     return x
 
@@ -812,6 +814,19 @@ def test_zonal_mean_nodata_nan(darr, zones):
     assert np.isnan(x.data[[0, -1], :]).all()
 
 
+def test_zonal_zone_nodata_nan(darr, zones):
+
+    res = np.array(
+        [["nan", 82.5], ["nan", 54.0], ["nan", 49.5], ["nan", 12.0], ["nan", 16.0]],
+        dtype="float64",
+    )
+
+    zones.attrs = {"nodata": 0}
+    z_ids = np.unique(zones.data)
+    x = darr.hdc.zonal.mean(zones, z_ids, dim_name="foo")
+    np.testing.assert_almost_equal(x, res)
+
+
 def test_zonal_dimname(darr, zones):
     z_ids = np.unique(zones.data)
     x = darr.zonal.mean(zones, z_ids, dim_name="foo")
@@ -823,6 +838,13 @@ def test_zonal_nodata_exc(darr, zones):
     del darr.attrs["nodata"]
     with pytest.raises(ValueError):
         _ = darr.zonal.mean(zones, z_ids)
+
+
+def test_zonal_zone_nodata_exc(darr, zones):
+    z_ids = np.unique(zones.data)
+    del zones.attrs["nodata"]
+    with pytest.raises(ValueError):
+        _ = darr.hdc.zonal.mean(zones, z_ids)
 
 
 def test_zonal_type_exc(darr, zones):


### PR DESCRIPTION
This PR includes an argument for a zonal nodata value in `do_mean` and the respective accessor, plus additional tests. This covers an edge case where we have valid data but no valid zone. 

**Note**:  The tests already use the `.hdc` accessor root, which is compatible with changes coming in with #21 

This closes #22 