### PR TITLE
Add valid observations

### DIFF
--- a/seasmon_xr/accessors.py
+++ b/seasmon_xr/accessors.py
@@ -564,15 +564,19 @@ class ZonalStatistics(AccessorBase):
         xx = xx.where(xx.notnull(), xx.nodata)
 
         num_zones = len(zone_ids)
-        dims = (xx.dims[0], dim_name)
-        coords = {dims[0]: xx.coords[dims[0]], dim_name: zone_ids}
+        dims = (xx.dims[0], dim_name, "stat")
+        coords = {
+            dims[0]: xx.coords[dims[0]],
+            dim_name: zone_ids,
+            "stat": ["mean", "valid"],
+        }
 
         if is_dask_collection(xx):
             dask_name = name
             if isinstance(dask_name, str):
                 dask_name = f"{name}-{tokenize(xx.data, zones.data, dtype)}"
 
-            chunks = [xx.data.chunks[0], (num_zones,)]
+            chunks = [xx.data.chunks[0], (num_zones,), (2,)]
 
             data = da.map_blocks(
                 do_mean,
@@ -582,7 +586,7 @@ class ZonalStatistics(AccessorBase):
                 xx.nodata,
                 zones.nodata,
                 drop_axis=[1, 2],
-                new_axis=1,
+                new_axis=[1, 2],
                 chunks=chunks,
                 dtype=dtype,
                 name=dask_name,

--- a/seasmon_xr/ops/zonal.py
+++ b/seasmon_xr/ops/zonal.py
@@ -10,10 +10,12 @@ def do_mean(pixels, z_pixels, num_zones, nodata, z_nodata, dtype="float64"):
     """Calculate the zonal mean.
 
     The mean for each pixel of `pixels` is calculated for each zone in
-    `z_pixels`.
+    `z_pixels` and returned with the number of valid pixels
 
     The zones in `z_pixels` have to be numbered in a linear fashion,
     starting with 0 for the first zone and num_zones for the last zone.
+
+    The shape of the returned array is (T, num_zones, 2).
 
     Args:
         pixels: input value pixels (T,Y,X)
@@ -24,8 +26,9 @@ def do_mean(pixels, z_pixels, num_zones, nodata, z_nodata, dtype="float64"):
     """
     t, nr, nc = pixels.shape
 
-    sums = np.zeros((t, num_zones), dtype=dtype)
-    valids = np.zeros((t, num_zones), dtype=dtype)
+    result = np.zeros((t, num_zones, 2), dtype=dtype)
+    # 0 mean
+    # 1 valids
 
     for tix in range(t):
         for rw in range(nr):
@@ -33,13 +36,13 @@ def do_mean(pixels, z_pixels, num_zones, nodata, z_nodata, dtype="float64"):
                 pix = pixels[tix, rw, cl]
                 z_idx = z_pixels[rw, cl]
                 if (pix != nodata) and (z_idx != z_nodata):
-                    sums[tix, z_idx] += pix
-                    valids[tix, z_idx] += 1
+                    result[tix, z_idx, 0] += pix
+                    result[tix, z_idx, 1] += 1
 
-        for idx in range(sums.shape[1]):
-            if valids[tix, idx] > 0:
-                sums[tix, idx] = sums[tix, idx] / valids[tix, idx]
+        for idx in range(result.shape[1]):
+            if result[tix, idx, 1] > 0:
+                result[tix, idx, 0] = result[tix, idx, 0] / result[tix, idx, 1]
             else:
-                sums[tix, idx] = np.nan
+                result[tix, idx, 0] = np.nan
 
-    return sums
+    return result

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -777,20 +777,38 @@ def test_whit_whitint_exception(darr):
 
 
 def test_zonal_mean(darr, zones):
+
     res = np.array(
-        [[33.5, 82.5], [72.0, 54.0], [81.5, 49.5], [28.0, 12.0], [63.0, 16.0]],
+        np.array(
+            [
+                [[33.5, 2.0], [82.5, 2.0]],
+                [[72.0, 2.0], [54.0, 2.0]],
+                [[81.5, 2.0], [49.5, 2.0]],
+                [[28.0, 2.0], [12.0, 2.0]],
+                [[63.0, 2.0], [16.0, 2.0]],
+            ]
+        ),
         dtype="float64",
     )
 
     z_ids = np.unique(zones.data)
     x = darr.hdc.zonal.mean(zones, z_ids)
+    assert x.shape == (5, 2, 2)
+    np.testing.assert_equal(x.coords["zones"].data, [0, 1])
+    assert list(x.coords["stat"].values) == ["mean", "valid"]
     np.testing.assert_almost_equal(x, res)
 
 
 def test_zonal_mean_nodata(darr, zones):
 
     res = np.array(
-        [[15.0, 82.5], [72.0, 54.0], [81.5, 49.5], [28.0, 12.0], [63.0, 16.0]],
+        [
+            [[15.0, 1.0], [82.5, 2.0]],
+            [[72.0, 2.0], [54.0, 2.0]],
+            [[81.5, 2.0], [49.5, 2.0]],
+            [[28.0, 2.0], [12.0, 2.0]],
+            [[63.0, 2.0], [16.0, 2.0]],
+        ],
         dtype="float64",
     )
 
@@ -807,13 +825,20 @@ def test_zonal_mean_nodata_nan(darr, zones):
 
     z_ids = np.unique(zones.data)
     x = darr.hdc.zonal.mean(zones, z_ids)
-    assert np.isnan(x.data[[0, -1], :]).all()
+    assert np.isnan(x.data[[0, -1], :, 0]).all()
+    assert np.all(x.data[[0, -1], :, 1] == 0)
 
 
 def test_zonal_mean_nodata_nan_float(darr, zones):
 
     res = np.array(
-        [[15.0, 82.5], [72.0, 54.0], [81.5, 49.5], [28.0, 12.0], [63.0, 16.0]],
+        [
+            [[15.0, 1.0], [82.5, 2.0]],
+            [[72.0, 2.0], [54.0, 2.0]],
+            [[81.5, 2.0], [49.5, 2.0]],
+            [[28.0, 2.0], [12.0, 2.0]],
+            [[63.0, 2.0], [16.0, 2.0]],
+        ],
         dtype="float64",
     )
 
@@ -828,7 +853,13 @@ def test_zonal_mean_nodata_nan_float(darr, zones):
 def test_zonal_zone_nodata_nan(darr, zones):
 
     res = np.array(
-        [["nan", 82.5], ["nan", 54.0], ["nan", 49.5], ["nan", 12.0], ["nan", 16.0]],
+        [
+            [["nan", 0.0], [82.5, 2.0]],
+            [["nan", 0.0], [54.0, 2.0]],
+            [["nan", 0.0], [49.5, 2.0]],
+            [["nan", 0.0], [12.0, 2.0]],
+            [["nan", 0.0], [16.0, 2.0]],
+        ],
         dtype="float64",
     )
 
@@ -841,7 +872,7 @@ def test_zonal_zone_nodata_nan(darr, zones):
 def test_zonal_dimname(darr, zones):
     z_ids = np.unique(zones.data)
     x = darr.hdc.zonal.mean(zones, z_ids, dim_name="foo")
-    assert x.dims == ("time", "foo")
+    assert x.dims == ("time", "foo", "stat")
 
 
 def test_zonal_nodata_exc(darr, zones):


### PR DESCRIPTION
This PR adds the number of valid pixels as new dimensions to the output (ref #24)

The returned array from `seasmon_xr.ops.zonal.mean` will have the shape `(t, num_zones, 2)` where the last two dimensions are for `["mean", "valid"]`. 

The accessor adds a new dimension to the returned xarray data array which is called `stat` and can be used for indexing like `x.sel(stat="mean")`.

As #24 states, we might need to add more stats (to be defined) and this is a good starting point as we can add to the "stat" dimension.

