### PR TITLE
Bump version and package conda on github actions

### DIFF
--- a/.github/workflows/publish-s3.yaml
+++ b/.github/workflows/publish-s3.yaml
@@ -21,6 +21,12 @@ jobs:
           path: ./wheels
           key: wheels-${{ github.sha }}
 
+      - uses: actions/cache@v3
+        id: pkgs_cache
+        with:
+          path: pkgs
+          key: pkgs-${{ github.sha }}
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -41,3 +47,10 @@ jobs:
 
         env:
           S3_DEST: s3://wfp-share/pypi/seasmon-xr
+
+      - name: upload conda packages to S3
+        run: |
+          aws s3 sync pkgs/ ${S3_DEST}/noarch/
+
+        env:
+          S3_DEST: s3://wfp-share/hdc

--- a/.github/workflows/seasmon_xr.yaml
+++ b/.github/workflows/seasmon_xr.yaml
@@ -184,3 +184,64 @@ jobs:
         run: |
           cd tests/
           python -m pytest -s .
+
+  package-conda:
+    runs-on: ubuntu-20.04
+    needs:
+      - wheels
+    steps:
+      - uses: actions/checkout@v3
+      
+      - uses: actions/cache@v3
+        id: pkgs_cache
+        with:
+          path: pkgs
+          key: pkgs-${{ github.sha }}
+
+      - uses: conda-incubator/setup-miniconda@v2
+        if: steps.conda_cache.outputs.cache-hit != 'true'
+        with:
+          channels: conda-forge
+          channel-priority: true
+          activate-environment: ""
+          mamba-version: "*"
+          use-mamba: true
+
+      - name: Install conda-build
+        run: |
+          conda info
+          conda list
+          mamba -V
+          mamba install conda-build
+
+      - name: Get Wheels
+        uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: wheels
+
+      - name: Unpack Patched Source 
+        run: |
+          src_tar=$(find wheels/ -type f -name "*.dev*.tar.gz" | head -1 | xargs readlink -f)
+          echo "Working with: $src_tar"
+          mkdir SRC
+          cd SRC && tar xvzf $src_tar --strip-components=1
+
+      - name: Build conda package
+        run: |
+          mkdir -p pkgs
+          version=$(awk '/^Version:/{print $2}' SRC/PKG-INFO)
+          echo "Version is $version"
+
+          make -C conda VERSION=$version SRC=$(readlink -f SRC)
+
+          find conda/build -type f -name "*.tar.bz2" | xargs -I{} mv {} pkgs/
+          ls -lh pkgs/
+
+      - name: Upload results (artifact)
+        uses: actions/upload-artifact@v3
+        with:
+          name: pkgs
+          path: pkgs
+          if-no-files-found: error
+

--- a/conda/Makefile
+++ b/conda/Makefile
@@ -1,3 +1,4 @@
+VERSION=0.1.2
 HDC_INDEX=../../hdc-conda-index
 
 .PHONY: all
@@ -5,7 +6,7 @@ all: refresh-index
 
 .PHONY: build
 build:
-	conda build --no-test --no-anaconda-upload --output-folder ./build recipe
+	env VERSION=$(VERSION) conda build --no-test --no-anaconda-upload --output-folder ./build recipe
 
 .PHONY: refresh-index
 refresh-index: build

--- a/conda/Makefile
+++ b/conda/Makefile
@@ -1,4 +1,6 @@
 VERSION=0.1.2
+# relative to recipe/
+SRC=../../
 HDC_INDEX=../../hdc-conda-index
 
 .PHONY: all
@@ -6,7 +8,7 @@ all: refresh-index
 
 .PHONY: build
 build:
-	env VERSION=$(VERSION) conda build --no-test --no-anaconda-upload --output-folder ./build recipe
+	env VERSION=$(VERSION) SRC=$(SRC) conda build --no-test --no-anaconda-upload --output-folder ./build recipe
 
 .PHONY: refresh-index
 refresh-index: build

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -1,12 +1,13 @@
 {% set name = "seasmon-xr" %}
 {% set version = os.environ.get("VERSION", "0.1.2") %}
+{% set src_path = os.environ.get("SRC", "../../") %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  path: ../../
+  path: {{src_path}}
 
 build:
   noarch: python

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "seasmon-xr" %}
-{% set _name = name.replace("-", "_") %}
-{% set version = "0.1.2.dev" %}
+{% set version = os.environ.get("VERSION", "0.1.2") %}
 
 package:
   name: {{ name|lower }}

--- a/seasmon_xr/_version.py
+++ b/seasmon_xr/_version.py
@@ -1,2 +1,2 @@
 """Version only in this file."""
-__version__ = "0.1.1"
+__version__ = "0.1.2"


### PR DESCRIPTION
Includes upload to S3, but without index, just package alone. We'll need some sort of trigger on AWS to recompute conda index when new files are added.
 